### PR TITLE
Create participations #9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,8 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.8)
+    nokogiri (1.13.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.3-x86_64-linux)
@@ -303,6 +305,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,6 +14,9 @@
 #  updated_at           :datetime         not null
 #
 class Event < ApplicationRecord
+  has_many :participations
+  belongs_to :user
+
   validates :title, presence: true
   validates :description, presence: true
   validates :number_of_members, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,7 +14,7 @@
 #  updated_at           :datetime         not null
 #
 class Event < ApplicationRecord
-  has_many :participations
+  has_many :participations, dependent: :destroy
   belongs_to :user
 
   validates :title, presence: true

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: participations
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  event_id   :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_participations_on_event_id_and_user_id  (event_id,user_id) UNIQUE
+#  index_participations_on_user_id               (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (event_id => events.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Participation < ApplicationRecord
+  belongs_to :user
+  belongs_to :event
+end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -21,4 +21,6 @@
 class Participation < ApplicationRecord
   belongs_to :user
   belongs_to :event
+
+  validates :user_id, uniqueness: { scope: :event_id}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@
 #
 class User < ApplicationRecord
   authenticates_with_sorcery!
-  has_many :event
+  has_many :events
   has_many :participations, dependent: :destroy
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 # Table name: users
 #
 #  id               :bigint           not null, primary key
-#  accept_random    :integer          default(NULL), not null
+#  accept_random    :integer          default("accepted"), not null
 #  crypted_password :string
 #  email            :string           not null
 #  name             :string           not null
@@ -20,6 +20,8 @@
 #
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_many :event
+  has_many :participations
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :event
-  has_many :participations
+  has_many :participations, dependent: :destroy
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -15,6 +15,8 @@ ja:
         mattermost_id: マターモストID
         password: パスワード
         password_confirmation: パスワード確認
+        accept_random: ランダム参加設定
+        role: 権限
       event:
         title: タイトル
         description: 詳細
@@ -29,7 +31,7 @@ ja:
       role:
         admin: 管理者
         general: 一般
-      accept_random: ランダム参加設定
+      accept_random:
         accepted: WELCOME
         not_accepted: SLEEPING 
     event:

--- a/db/migrate/20220310133405_create_participations.rb
+++ b/db/migrate/20220310133405_create_participations.rb
@@ -1,0 +1,12 @@
+class CreateParticipations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :participations do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :event, null: false, foreign_key: true, index: false
+
+      t.timestamps
+    end
+
+    add_index :participations, %i[event_id user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,25 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2022_03_08_113447) do
-ActiveRecord::Schema.define(version: 2022_03_08_011836) do
+ActiveRecord::Schema.define(version: 2022_03_10_133405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "users", force: :cascade do |t|
-    t.string "mattermost_id", null: false
-    t.string "name", null: false
-    t.string "email", null: false
-    t.integer "accept_random", default: 0, null: false
-    t.string "crypted_password"
-    t.string "salt"
-    t.integer "role", default: 0, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["mattermost_id"], name: "index_users_on_mattermost_id", unique: true
 
   create_table "events", force: :cascade do |t|
     t.string "title", null: false
@@ -42,4 +27,29 @@ ActiveRecord::Schema.define(version: 2022_03_08_011836) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "participations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "event_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id", "user_id"], name: "index_participations_on_event_id_and_user_id", unique: true
+    t.index ["user_id"], name: "index_participations_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "mattermost_id", null: false
+    t.string "name", null: false
+    t.string "email", null: false
+    t.integer "accept_random", default: 0, null: false
+    t.string "crypted_password"
+    t.string "salt"
+    t.integer "role", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["mattermost_id"], name: "index_users_on_mattermost_id", unique: true
+  end
+
+  add_foreign_key "participations", "events"
+  add_foreign_key "participations", "users"
 end

--- a/spec/factories/participations.rb
+++ b/spec/factories/participations.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: participations
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  event_id   :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_participations_on_event_id_and_user_id  (event_id,user_id) UNIQUE
+#  index_participations_on_user_id               (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (event_id => events.id)
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :participation do
+    user { nil }
+    event { nil }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@
 # Table name: users
 #
 #  id               :bigint           not null, primary key
-#  accept_random    :integer          default(NULL), not null
+#  accept_random    :integer          default("accepted"), not null
 #  crypted_password :string
 #  email            :string           not null
 #  name             :string           not null

--- a/spec/models/participation_spec.rb
+++ b/spec/models/participation_spec.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: participations
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  event_id   :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_participations_on_event_id_and_user_id  (event_id,user_id) UNIQUE
+#  index_participations_on_user_id               (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (event_id => events.id)
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe Participation, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@
 # Table name: users
 #
 #  id               :bigint           not null, primary key
-#  accept_random    :integer          default(NULL), not null
+#  accept_random    :integer          default("accepted"), not null
 #  crypted_password :string
 #  email            :string           not null
 #  name             :string           not null


### PR DESCRIPTION
概要
---
ユーザーとイベントの中間テーブルを作成しました。

やったこと
---
- ユーザーとイベントの中間テーブル作成。 78bb6be
- userモデル・eventモデルにアソシエーションを追加。 42471ef
- イベント終了と同時に関連した参加を削除するよう追加。 801fe98
- 日本語対応化によるエラー解消。 0b7760a

補足
---
- ログイン機能が未実装でユーザーが登録されていないことで現状ではエラーが出るようになってます。
  中間テーブルなので地引さん・小野田さんと相談しながら進めていきたいと考えています！
[![Image from Gyazo](https://i.gyazo.com/19b05a657584b7578e13a71cdfaae164.png)](https://gyazo.com/19b05a657584b7578e13a71cdfaae164)
- 宮本さんと話してた `user.rb`への　
  `has_many :participating_events, through: :participations, source: :event`
はメソッド作成時に追加した方がわかりやすいと考えたため、現段階では追加してません。

コミット時、メッセージの最後にIssue番号つけるの忘れました。すみません🙏