### PR TITLE
refactor: githubログイン実装後の懸念点を修正

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,8 +1,6 @@
 class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new]
 
-  def new; end
-
   def destroy
     logout
     redirect_to root_path, success: 'ログアウトしました'

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,6 +1,4 @@
 class UserSessionsController < ApplicationController
-  skip_before_action :require_login, only: %i[new]
-
   def destroy
     logout
     redirect_to root_path, success: 'ログアウトしました'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,12 +13,10 @@
 #  salt              :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  mattermost_id     :string
 #
 # Indexes
 #
-#  index_users_on_email          (email) UNIQUE
-#  index_users_on_mattermost_id  (mattermost_id) UNIQUE
+#  index_users_on_email  (email) UNIQUE
 #
 class User < ApplicationRecord
   authenticates_with_sorcery!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,8 @@
 #
 # Indexes
 #
-#  index_users_on_email  (email) UNIQUE
+#  index_users_on_email        (email) UNIQUE
+#  index_users_on_github_name  (github_name) UNIQUE
 #
 class User < ApplicationRecord
   authenticates_with_sorcery!
@@ -33,7 +34,7 @@ class User < ApplicationRecord
                                                           new_record? || changes[:crypted_password]
                                                         }
   validates :mattermost_id, uniqueness: true
-  validates :github_name, presence: true
+  validates :github_name, uniqueness: true, presence: true
   validates :name, length: { maximum: 20 }
   validates :email, uniqueness: true, presence: true
   validates :accept_random, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,8 @@
 #  accept_random     :integer          default("accepted"), not null
 #  crypted_password  :string
 #  email             :string           not null
-#  name              :string           not null
+#  github_name       :string           not null
+#  name              :string
 #  remote_avatar_url :string
 #  role              :integer          default("general"), not null
 #  salt              :string
@@ -34,7 +35,8 @@ class User < ApplicationRecord
                                                           new_record? || changes[:crypted_password]
                                                         }
   validates :mattermost_id, uniqueness: true
-  validates :name, presence: true, length: { maximum: 20 }
+  validates :github_name, presence: true
+  validates :name, length: { maximum: 20 }
   validates :email, uniqueness: true, presence: true
   validates :accept_random, presence: true
 

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -11,7 +11,7 @@
           <%= link_to 'Events', events_path ,class: 'nav-link' %>
         </li>
         <li class="nav-item">
-          <%= link_to 'Login', login_path ,class: 'nav-link' %>
+         <%= link_to 'Login', auth_at_provider_path(provider: :github), class: 'nav-link' %>
         </li>
       </ul>
     </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,3 +1,3 @@
 <%= link_to auth_at_provider_path(provider: :github), class: "btn btn-light" do %>
-    <span class="has-text-weight-medium">Sign in with Github</span>
+  <span class="has-text-weight-medium">Sign in with Github</span>
 <% end %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,1 +1,3 @@
-Test top_page
+<%= link_to auth_at_provider_path(provider: :github), class: "btn btn-light" do %>
+    <span class="has-text-weight-medium">Sign in with Github</span>
+<% end %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,3 +1,0 @@
-<%= link_to auth_at_provider_path(provider: :github), class: "btn btn-light" do %>
-    <span class="has-text-weight-medium">Sign in with Github</span>
-<% end %>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -139,7 +139,7 @@ Rails.application.config.sorcery.configure do |config|
   config.github.key = Rails.application.credentials.dig(:github, :key)
   config.github.secret = Rails.application.credentials.dig(:github, :secret)
   config.github.callback_url = Rails.application.credentials.dig(:github, :callback_url)
-  config.github.user_info_mapping = { email: 'email', name: 'login',
+  config.github.user_info_mapping = { email: 'email', github_name: 'login',
                                       remote_avatar_url: 'avatar_url' }
   config.github.scope = 'user:email'
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,5 @@ Rails.application.routes.draw do
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'
   get 'oauth/:provider', to: 'oauths#oauth', as: :auth_at_provider
-  get 'login', to: 'user_sessions#new'
   delete 'logout', to: 'user_sessions#destroy'
 end

--- a/db/migrate/20220323063156_add_column_users_to_github_name.rb
+++ b/db/migrate/20220323063156_add_column_users_to_github_name.rb
@@ -1,0 +1,5 @@
+class AddColumnUsersToGithubName < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :github_name, :string, null: false
+  end
+end

--- a/db/migrate/20220323064145_change_column_name_to_users.rb
+++ b/db/migrate/20220323064145_change_column_name_to_users.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    change_column :users, :name, :string, null: true
+  end
+end

--- a/db/migrate/20220323065154_remove_column_mattermost_id_to_users.rb
+++ b/db/migrate/20220323065154_remove_column_mattermost_id_to_users.rb
@@ -1,0 +1,5 @@
+class RemoveColumnMattermostIdToUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :mattermost_id, :string
+  end
+end

--- a/db/migrate/20220324011540_add_index_github_name_to_users.rb
+++ b/db/migrate/20220324011540_add_index_github_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddIndexGithubNameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_index :users, :github_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_23_064145) do
+ActiveRecord::Schema.define(version: 2022_03_23_065154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,6 @@ ActiveRecord::Schema.define(version: 2022_03_23_064145) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "mattermost_id"
     t.string "name"
     t.string "email", null: false
     t.integer "accept_random", default: 0, null: false
@@ -78,7 +77,6 @@ ActiveRecord::Schema.define(version: 2022_03_23_064145) do
     t.string "remote_avatar_url"
     t.string "github_name", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["mattermost_id"], name: "index_users_on_mattermost_id", unique: true
   end
 
   add_foreign_key "events", "categories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_23_065154) do
+ActiveRecord::Schema.define(version: 2022_03_24_011540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 2022_03_23_065154) do
     t.string "remote_avatar_url"
     t.string "github_name", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["github_name"], name: "index_users_on_github_name", unique: true
   end
 
   add_foreign_key "events", "categories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_20_211041) do
+ActiveRecord::Schema.define(version: 2022_03_23_064145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 2022_03_20_211041) do
 
   create_table "users", force: :cascade do |t|
     t.string "mattermost_id"
-    t.string "name", null: false
+    t.string "name"
     t.string "email", null: false
     t.integer "accept_random", default: 0, null: false
     t.string "crypted_password"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2022_03_20_211041) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "remote_avatar_url"
+    t.string "github_name", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["mattermost_id"], name: "index_users_on_mattermost_id", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,7 +6,8 @@
 #  accept_random     :integer          default("accepted"), not null
 #  crypted_password  :string
 #  email             :string           not null
-#  name              :string           not null
+#  github_name       :string           not null
+#  name              :string
 #  remote_avatar_url :string
 #  role              :integer          default("general"), not null
 #  salt              :string

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,12 +13,10 @@
 #  salt              :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  mattermost_id     :string
 #
 # Indexes
 #
-#  index_users_on_email          (email) UNIQUE
-#  index_users_on_mattermost_id  (mattermost_id) UNIQUE
+#  index_users_on_email  (email) UNIQUE
 #
 FactoryBot.define do
   factory :user do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,7 +16,8 @@
 #
 # Indexes
 #
-#  index_users_on_email  (email) UNIQUE
+#  index_users_on_email        (email) UNIQUE
+#  index_users_on_github_name  (github_name) UNIQUE
 #
 FactoryBot.define do
   factory :user do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,12 +13,10 @@
 #  salt              :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  mattermost_id     :string
 #
 # Indexes
 #
-#  index_users_on_email          (email) UNIQUE
-#  index_users_on_mattermost_id  (mattermost_id) UNIQUE
+#  index_users_on_email  (email) UNIQUE
 #
 require 'rails_helper'
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,7 +6,8 @@
 #  accept_random     :integer          default("accepted"), not null
 #  crypted_password  :string
 #  email             :string           not null
-#  name              :string           not null
+#  github_name       :string           not null
+#  name              :string
 #  remote_avatar_url :string
 #  role              :integer          default("general"), not null
 #  salt              :string

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,7 +16,8 @@
 #
 # Indexes
 #
-#  index_users_on_email  (email) UNIQUE
+#  index_users_on_email        (email) UNIQUE
+#  index_users_on_github_name  (github_name) UNIQUE
 #
 require 'rails_helper'
 


### PR DESCRIPTION
##  概要
githubログイン後の懸念点を修正いたしました。

## やったこと
- loginページの削除
- usersテーブルのgithub_nameカラムの追加, nameカラムのnullを許容
- usersテーブルのmattermost_idを削除

## コメント
### nameカラムのnullを許容した理由
今回github_nameというカラムを用意してそこにgithubから取得した名前が登録されるようにしましたが
登録時に既存のnameカラムのデータはnilになってしまうのでnullを許容する設定にしています。

ユーザー新規登録→ユーザー設定画面に遷移→nameを登録してもらうという方向で
バリデーションはviewの方で設定するしか今のテーブル構成ではなさそうです。

こちらもご意見あればよろしくお願いいたします！