### PR TITLE
マイページでのイベント表示を過去と現在以降でそれぞれ表示する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,3 +66,7 @@ Metrics/BlockLength:
 # dependent: :destroyがなくても許容する
 Rails/HasManyOrHasOneDependent:
   Enabled: false
+
+# 複数行scopeに対してlamdaの省略記法「->」を使用可能にする
+Style/Lambda:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,7 @@ Metrics/LineLength:
   IgnoredPatterns: ['(\A|\s)#']
   Exclude:
     - "db/migrate/*.rb"
+    - "app/models/application_record.rb"
 
 # メソッドの行数を20行までにする
 Metrics/MethodLength:

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,7 @@ class EventsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
 
   def index
-    @events = Event.includes(%i[user category]).date_from_now_on.page(params[:page]).per(10)
+    @events = Event.includes(%i[user category]).from_today.page(params[:page]).per(10)
   end
 
   def show

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,7 @@ class EventsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
 
   def index
-    @events = Event.includes(%i[user category]).date_from_now_on.page(params[:page]).per(10)
+    @events = Event.includes(%i[user category]).page(params[:page]).per(10)
   end
 
   def show

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,7 @@ class EventsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
 
   def index
-    @events = Event.includes(%i[user category]).page(params[:page]).per(10)
+    @events = Event.includes(%i[user category]).date_from_now_on.page(params[:page]).per(10)
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,9 +4,9 @@ class UsersController < ApplicationController
 
   def show
     @future_events = current_user.participating_events.includes(%i[user category])
-      .where(scheduled_date: Time.current..Time.current.since(1.year))
+      .date_from_now_on
     @past_events = current_user.participating_events.includes(%i[user category])
-      .where(scheduled_date: Time.current.ago(1.year)...Time.current).order(scheduled_date: :desc)
+      .date_till_now
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,10 +3,8 @@ class UsersController < ApplicationController
   def edit; end
 
   def show
-    @future_events = current_user.participating_events.includes(%i[user category])
-      .date_from_now_on
-    @past_events = current_user.participating_events.includes(%i[user category])
-      .date_till_now
+    @future_events = current_user.participating_events.includes(%i[user category]).date_from_now_on
+    @past_events = current_user.participating_events.includes(%i[user category]).date_till_now
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,10 @@ class UsersController < ApplicationController
   def edit; end
 
   def show
-    @events = current_user.participating_events.includes(%i[user
-                                                            category]).order(scheduled_date: :asc)
+    @future_events = current_user.participating_events.includes(%i[user category])
+      .where(scheduled_date: Time.current..Time.current.since(1.year))
+    @past_events = current_user.participating_events.includes(%i[user category])
+      .where(scheduled_date: Time.current.ago(1.year)...Time.current).order(scheduled_date: :desc)
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,8 @@ class UsersController < ApplicationController
   def edit; end
 
   def show
-    @future_events = current_user.participating_events.includes(%i[user category]).date_from_now_on
-    @past_events = current_user.participating_events.includes(%i[user category]).date_till_now
+    @events_from_today = current_user.participating_events.includes(%i[user category]).from_today
+    @events_till_yesterday = current_user.participating_events.includes(%i[user category]).till_yesterday
   end
 
   def update

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  scope :date_from_now_on, -> { where("scheduled_date >= ?", Time.current) }
-  scope :date_till_now, -> { where("scheduled_date < ?", Time.current).order(scheduled_date: :desc) }
+  scope :date_from_now_on, -> { where('scheduled_date >= ?', Time.current) }
+  scope :date_till_now,
+        -> { where('scheduled_date < ?', Time.current).order(scheduled_date: :desc) }
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,6 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  scope :date_from_now_on, -> { where("scheduled_date >= ?", Time.current) }
+  scope :date_till_now, -> { where("scheduled_date < ?", Time.current).order(scheduled_date: :desc) }
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,6 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  scope :date_from_now_on, -> { where('scheduled_date >= ?', Time.current) }
-  scope :date_till_now,
-        -> { where('scheduled_date < ?', Time.current).order(scheduled_date: :desc) }
+  scope :from_today, -> { where('scheduled_date >= ?', Time.current.beginning_of_day) }
+  scope :till_yesterday, -> { where('scheduled_date < ?', Time.current.beginning_of_day).order(scheduled_date: :desc) }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -41,8 +41,6 @@ class Event < ApplicationRecord
 
   enum pickable_mode: { all_applicant: 0, applicant_and_random: 1, random: 2 }
 
-  scope :date_from_now_on, -> { where(scheduled_date: Time.current..Time.current.since(3.years)) }
-
   def created_by?(user)
     return false unless user
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -25,7 +25,7 @@
         <td><%= event.description %></td>
         <td><%= event.number_of_members %></td>
         <td><%= event.number_of_applicants %></td>
-        <td><%= event.scheduled_date %></td>
+        <td><%= l event.scheduled_date, format: :long %></td>
         <td><%= event.place %></td>
         <td><%= event.pickable_mode_i18n %></td>
         <!-- 下記記述の場合おそらくn+1が起きるので、実装時は注意する -->

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -22,7 +22,7 @@
 
 <p>
   <strong>Scheduled date:</strong>
-  <%= @event.scheduled_date %>
+  <%= l event.scheduled_date, format: :long %>
 </p>
 
 <p>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -22,7 +22,7 @@
 
 <p>
   <strong>Scheduled date:</strong>
-  <%= l event.scheduled_date, format: :long %>
+  <%= l @event.scheduled_date, format: :long %>
 </p>
 
 <p>

--- a/app/views/users/_event.html.erb
+++ b/app/views/users/_event.html.erb
@@ -12,7 +12,7 @@
   <tbody>
       <tr>
         <td><%= event.title %></td>
-        <td><%= event.scheduled_date %></td>
+        <td><%= l event.scheduled_date, format: :long %></td>
         <td><%= event.place %></td>
         <td><%= event.user.name %></td>
         <td><%= event.category.name %></td>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,10 +34,10 @@
           </td>
         </tr>
         <tr>
-          <th>参加予定のイベント</th>
+          <th>参加中・参加予定のイベント</th>
           <td> 
-            <% if @future_events.present? %>
-              <%= render partial: 'users/event', collection: @future_events %>
+            <% if @events_from_today.present? %>
+              <%= render partial: 'users/event', collection: @events_from_today %>
             <% else %>
               <p>参加予定のイベントはありません</p>
             <% end %>
@@ -53,8 +53,8 @@
         <tr>
           <th>参加したイベント</th>
           <td> 
-            <% if @past_events.present? %>
-              <%= render partial: 'users/event', collection: @past_events %>
+            <% if @events_till_yesterday.present? %>
+              <%= render partial: 'users/event', collection: @events_till_yesterday %>
             <% else %>
               <p>過去に参加したイベントはありません</p>
             <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,15 +34,33 @@
           </td>
         </tr>
         <tr>
-          <th>参加イベント一覧</th>
+          <th>参加予定のイベント</th>
           <td> 
-             <% if @events.present? %>
-               <%= render partial: 'users/event', collection: @events %>
-             <% else %>
-               <p>参加しているイベントはありません</p>
-             <% end %>
+            <% if @future_events.present? %>
+              <%= render partial: 'users/event', collection: @future_events %>
+            <% else %>
+              <p>参加予定のイベントはありません</p>
+            <% end %>
           </td>
         </tr>
+        <!--- 境界がわかりにくいため表示が見やすいようにラインで分割 -->
+        <tr> 
+          <th>----------------------
+          <td>
+            -----------------------------------------------------
+          </td>
+        </tr>
+        <tr>
+          <th>参加したイベント</th>
+          <td> 
+            <% if @past_events.present? %>
+              <%= render partial: 'users/event', collection: @past_events %>
+            <% else %>
+              <p>過去に参加したイベントはありません</p>
+            <% end %>
+          </td>
+        </tr>
+
       </table>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,7 +29,7 @@
             <% if @user.hiyoconne_url.present? %>
               <%= link_to 'ひよコネリンク', @user.hiyoconne_url %>
             <% else %>
-              <p>ひよこねリンクは未登録です</p>
+              <p>ひよコネリンクは未登録です</p>
             <% end %>
           </td>
         </tr>


### PR DESCRIPTION
## 概要
#48 に基づき、マイページでのイベントの表示を
- これから参加するイベント
  - 開催日時が現在から未来
- 参加したイベント
  - 開催日時が現在より過去

と分けて表示できるようにしました。
また、 「関連する箇所の細かい調整」「rubocopの設定を一部追記」も行いました！
コメントで説明します！

## 確認方法
イベント作成→参加→マイページで下記項目を確認
- 参加したイベントがそれぞれ開催日時によって正しく分けて表示されているか
- 該当するイベントがない場合、それぞれ「参加予定のイベントはありません」「過去に参加したイベントはありません」と表示されるか

## 影響範囲
- view
  - マイページ
  - イベント詳細ページ
- controller
  - events
  - users
  - application_record 

## チェックリスト
- [x] 機能の追加
- [x] イベントの開催日時のフォーマットの変更
- [x] scopeへの切り出し
- [x] rubocopの実行と設定の追加
- [x] 動作の確認

過去未来どちらのイベントにも参加している場合
https://gyazo.com/3849828c5bb046495fa73c817751d202

なにも参加していない場合
https://gyazo.com/ece62d86548bef5cbff4aa34ff4d7426


## コメント
Filechangedに直接記入します！
## Close Issues
Close #48 