### PR TITLE
ひよコネURLに入る値を制御する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
   validates :accept_random, presence: true
   validates :hiyoconne_url, uniqueness: true,
-                            format: { with: %r{\Ahttps://hiyoco-connect\.herokuapp\.com/profiles/\d{1,3}},
+                            format: { with: %r{\Ahttps:\/\/hiyoco-connect\.herokuapp\.com\/profiles\/\d{1,3}},
                                       message: 'が不正なURLです。誤解だったらゴメンね！' }
 
   enum role: { general: 0, admin: 1 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,8 @@ class User < ApplicationRecord
   has_many :authentications, dependent: :destroy
   accepts_nested_attributes_for :authentications
 
+
+
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: lambda {
@@ -40,7 +42,9 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 20 }, on: :update
   validates :email, uniqueness: true, presence: true
   validates :accept_random, presence: true
-  validates :hiyoconne_url, uniqueness: true
+  validates :hiyoconne_url, uniqueness: true, 
+                            format: { with: /\Ahttps:\/\/hiyoco-connect\.herokuapp\.com\/profiles\/\d{1,3}/,
+                                      message: 'が不正なURLです。誤解だったらゴメンね！'}
 
   enum role: { general: 0, admin: 1 }
   enum accept_random: { accepted: 0, denied: 1 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,8 +31,6 @@ class User < ApplicationRecord
   has_many :authentications, dependent: :destroy
   accepts_nested_attributes_for :authentications
 
-
-
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: lambda {
@@ -42,9 +40,9 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 20 }, on: :update
   validates :email, uniqueness: true, presence: true
   validates :accept_random, presence: true
-  validates :hiyoconne_url, uniqueness: true, 
-                            format: { with: /\Ahttps:\/\/hiyoco-connect\.herokuapp\.com\/profiles\/\d{1,3}/,
-                                      message: 'が不正なURLです。誤解だったらゴメンね！'}
+  validates :hiyoconne_url, uniqueness: true,
+                            format: { with: %r{\Ahttps://hiyoco-connect\.herokuapp\.com/profiles/\d{1,3}},
+                                      message: 'が不正なURLです。誤解だったらゴメンね！' }
 
   enum role: { general: 0, admin: 1 }
   enum accept_random: { accepted: 0, denied: 1 }


### PR DESCRIPTION
## 概要
#55 に基づきひよコネURLに入る値を制御するバリデーションをuser.rbに追加しました！
`https://hiyoco-connect.herokuapp.com/profiles/〇〇`の形で〇〇には0~999の値を許容する実装にしてますが、
**この許容でOKかご意見いただけますと**助かります！！
その他の詳細は #55 にまとめているので、そちらをご参照いただければと思います！🙏🏻

## 確認方法
#### 不正な値①（`https://www.google.com/`）
<img width="662" alt="スクリーンショット 2022-04-03 22 01 50" src="https://user-images.githubusercontent.com/71510236/161430580-14e1690d-45ce-4b2b-a094-2a0c6cb14ccf.png">

#### 不正な値②（`https://hiyoco-connect.herokuapp.com/profiles/`）数字がない
<img width="662" alt="スクリーンショット 2022-04-03 22 34 13" src="https://user-images.githubusercontent.com/71510236/161430643-17a84150-6b18-45b9-8ebc-0db71bbd062e.png">

#### 正常な値（`https://hiyoco-connect.herokuapp.com/profiles/15`）
https://gyazo.com/54e915567a279d0751dfd97114c9a497

## 影響範囲
- `user.rb`
## チェックリスト
- 実装
- 動作確認
- rubocop
## コメント
#55 に記載したため今回は無しです！
## Close Issues
Close #55 