### PR TITLE
Fix:  #55 によりひよコネURLが空欄で更新できなくなっていた不具合を修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
   validates :accept_random, presence: true
   validates :hiyoconne_url, uniqueness: true,
-                            format: { with: %r{\Ahttps:\/\/hiyoco-connect\.herokuapp\.com\/profiles\/\d{1,3}},
+                            format: { with: %r{\A\z|\Ahttps://hiyoco-connect\.herokuapp\.com/profiles/\d{1,3}\Z},
                                       message: 'が不正なURLです。誤解だったらゴメンね！' }
 
   enum role: { general: 0, admin: 1 }


### PR DESCRIPTION
## 概要
#55 で追加したバリデーションによりひよコネURLを空欄で更新した際にバリデーションに引っかかってしまう不具合が出ていたため
空値で更新できるよう修正しました！

## 確認方法
https://gyazo.com/561df020e7273a449dac520360f7b692
## 影響範囲
- `user.rb`
## チェックリスト
- 修正
- 動作確認
- rubocop
## コメント
#58 に記載してます！
## Close Issues
Close #58 
