### PR TITLE
Feat: 全体のカラーテーマ、フォントの定義とfont-awesomeの導入 #53

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,30 @@
  *= require_tree .
  *= require_self
  */
+
+ /* font-awesomeの読み込み */
+@import '@fortawesome/fontawesome-free/scss/fontawesome';
+
+ /* フォント */
+@import url('https://fonts.googleapis.com/css2?family=Coda+Caption:wght@800&display=swap');
+* {
+  font-family: 'Coda Caption', sans-serif;;
+}
+
+/* メインカラー */
+.red {
+  color: #FF4273;
+}
+.orange {
+  color: #FF9D76;
+}
+.yellow {
+  color: #FFFDE1;
+}
+.skyblue {
+  color: #1FFFFF;
+}
+
+body {
+  background-color: #FFFDE1 !important;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -12,6 +12,9 @@ import "channels"
 import "bootstrap"
 import "../stylesheets/application.scss"
 
+// font-awesomeの読み込み
+import '@fortawesome/fontawesome-free/js/all'
+
 // JSファイルの読み込み（現段階では必要なし）
 // import "./common"
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,3 +1,6 @@
 <h1>Editing User</h1>
 
+<!-- font-awesomeの動作確認 -->
+<i class="fa-brands fa-twitter" style="color: deepskyblue;"></i>
+
 <%= render 'form', user: @user %>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pickable",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.1.1",
     "@popperjs/core": "^2.11.2",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -912,6 +912,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-free@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.1.tgz#bf5d45611ab74890be386712a0e5d998c65ee2a1"
+  integrity sha512-J/3yg2AIXc9wznaVqpHVX3Wa5jwKovVF0AMYSnbmcXTiL3PpRPfF58pzWucCwEiCJBp+hCNRLWClTomD8SseKg==
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
## 概要
全体カラーテーマの定義と、font-awesomeの導入を行いました！
進捗を合わせる目的のため、地引さんのレビュー次第マージいたします！
to @jibiking 
チェックリストよければご活用ください！🙌🏻

## 確認方法
割愛
## 影響範囲
FileChangedを参照。

## チェックリスト
- [x] カラーテーマの定義が問題ないか

## コメント
割愛
## Close Issues
なし