### PR TITLE
ひよコネURLの未登録ユーザーが一人いると他のユーザーが未登録で更新できない不具合を解決

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,9 +17,8 @@
 #
 # Indexes
 #
-#  index_users_on_email          (email) UNIQUE
-#  index_users_on_github_name    (github_name) UNIQUE
-#  index_users_on_hiyoconne_url  (hiyoconne_url) UNIQUE
+#  index_users_on_email        (email) UNIQUE
+#  index_users_on_github_name  (github_name) UNIQUE
 #
 class User < ApplicationRecord
   authenticates_with_sorcery!
@@ -42,7 +41,7 @@ class User < ApplicationRecord
   validates :accept_random, presence: true
   validates :hiyoconne_url, uniqueness: true,
                             format: { with: %r{\A\z|\Ahttps://hiyoco-connect\.herokuapp\.com/profiles/\d{1,3}\Z},
-                                      message: 'が不正なURLです。誤解だったらゴメンね！' }
+                                      message: 'が不正なURLです。誤解だったらゴメンね！' }, allow_blank: true
 
   enum role: { general: 0, admin: 1 }
   enum accept_random: { accepted: 0, denied: 1 }

--- a/db/migrate/20220412054124_remove_uniqueness_of_hiyoconne_url.rb
+++ b/db/migrate/20220412054124_remove_uniqueness_of_hiyoconne_url.rb
@@ -1,0 +1,5 @@
+class RemoveUniquenessOfHiyoconneUrl < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :users, :hiyoconne_url, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_01_022056) do
+ActiveRecord::Schema.define(version: 2022_04_12_054124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,7 +77,6 @@ ActiveRecord::Schema.define(version: 2022_04_01_022056) do
     t.string "hiyoconne_url"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["github_name"], name: "index_users_on_github_name", unique: true
-    t.index ["hiyoconne_url"], name: "index_users_on_hiyoconne_url", unique: true
   end
 
   add_foreign_key "events", "categories"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,9 +17,8 @@
 #
 # Indexes
 #
-#  index_users_on_email          (email) UNIQUE
-#  index_users_on_github_name    (github_name) UNIQUE
-#  index_users_on_hiyoconne_url  (hiyoconne_url) UNIQUE
+#  index_users_on_email        (email) UNIQUE
+#  index_users_on_github_name  (github_name) UNIQUE
 #
 FactoryBot.define do
   factory :user do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,9 +17,8 @@
 #
 # Indexes
 #
-#  index_users_on_email          (email) UNIQUE
-#  index_users_on_github_name    (github_name) UNIQUE
-#  index_users_on_hiyoconne_url  (hiyoconne_url) UNIQUE
+#  index_users_on_email        (email) UNIQUE
+#  index_users_on_github_name  (github_name) UNIQUE
 #
 require 'rails_helper'
 


### PR DESCRIPTION
## 概要
#78 について、動作を確認したところ予想通り、ひよコネURLが未登録のユーザーが一人でもいると
他のユーザーがひよコネURLが未登録で更新する際にユニークネス制約に引っかかり更新ができない不具合が生じていました。（ユニーク制約はupdateアクションのみへの適用のため登録時は問題なし）

解決方法として、
1. まず、DB上のひよコネURLに対するユニークインデックスを削除
2. userモデルに記載しているひよコネURLに対するバリデーションにallow_blankオプションを渡すことで空の値で一意制約に引っかからないように（オプションがないとユニーク制約に引っかかる。　＆　ユニーク制約がないと重複した値が登録されてしまう）
allow_blankオプションの参考：[こちら](https://railsguides.jp/active_record_validations.html#:~:text=%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82-,3.2%20%3Aallow_blank,-%3Aallow_blank%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AF)

こちらの方法で対応しました。
懸念点としては、バリデーションとDB上の制約が統一されていないことでなにか問題が起こる可能性がほんの少し考えられますが、現状自分としてはこれが妥協点かと思います。
rubocop先生にもそのことを怒られますが、userモデルをその監視対象から外すと良くないと思うので怒られたままにしています！
![スクリーンショット 2022-04-12 15 00 07](https://user-images.githubusercontent.com/71510236/162891010-67befd40-c083-48c8-9759-bdc8dd39da04.png)

## 確認方法
マイグレーションを追加しているため、db:migrate必須です！
その後、自分以外にひよコネURLが空のユーザーを作成し、自分のひよコネURLを空で更新できるか確認してください。

## 影響範囲
- user.rb
- db/

## コメント
割愛

## Close Issues
#78 
