### PR TITLE
イベント詳細に改行・リンクを表示 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem 'kaminari'
 # cssをinline変換
 gem 'premailer-rails'
 
+# リンク作成
+gem 'rinku'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]\

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,6 +250,7 @@ GEM
     regexp_parser (2.2.0)
     require_all (3.0.0)
     rexml (3.2.5)
+    rinku (2.0.6)
     rspec-core (3.10.2)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.2)
@@ -363,6 +364,7 @@ DEPENDENCIES
   rails (~> 6.1.4, >= 6.1.4.4)
   rails-i18n (~> 6.0)
   rails_best_practices
+  rinku
   rspec-rails (~> 5.0.0)
   rubocop
   rubocop-performance

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -20,7 +20,7 @@
       <%= @event.user.name %>
     </div>
     <div class="h4 text-center mx-auto mt-2 col-8">
-      <%= raw Rinku.auto_link(simple_format(h(@event.description), {}, sanitize: false, wrapper_tag: "div") ,:all, 'target="_blank"')%>
+      <%= raw Rinku.auto_link(simple_format(h(@event.description), {}, sanitize: false, wrapper_tag: "div") ,:all, 'target="_blank"' 'rel="noopener noreferrer"')%>
     </div>
   </div>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -20,7 +20,7 @@
       <%= @event.user.name %>
     </div>
     <div class="h4 text-center mx-auto mt-2 col-8">
-      <%= @event.description %>
+      <%= raw Rinku.auto_link(simple_format(h(@event.description), {}, sanitize: false, wrapper_tag: "div") ,:all, 'target="_blank"')%>
     </div>
   </div>
 


### PR DESCRIPTION
## 概要
#84 に基づき、イベント詳細に改行・リンクを表示させました！

## やったこと
- [x] gem `rinku`を追加
- [x] simple_formatを使用

## 動作確認
[![Image from Gyazo](https://i.gyazo.com/4fc1aeb894bfbaa47a0d97ac27e83f8c.png)](https://gyazo.com/4fc1aeb894bfbaa47a0d97ac27e83f8c)

## 参考
[\[Rails\]Rinkuを使って、URLを自動的にリンクにする \- JPDEBUG\.COM](https://jpdebug.com/p/2445666)
[【Rails】simple\_formatとは \- Qiita](https://qiita.com/mmaumtjgj/items/1b672f3accd37387b2f3)

## Close Issues
Close #84