### PR TITLE
refactor: エラーメッセージの共通化

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -123,3 +123,10 @@ body {
     color: inherit;
   }
 }
+
+// エラーメッセージの表示崩れを防ぐ
+.error_msg_with_errors {
+  width: 40%;
+  margin: 0 auto;
+  text-align: left;
+}

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,16 +1,5 @@
 <%= form_with(model: category) do |form| %>
-  <% if category.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(category.errors.count, "error") %> prohibited this category from being saved:</h2>
-
-      <ul>
-        <% category.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
+  <%= render 'shared/error_messages', object: f.object %>
   <div class="field">
     <%= form.label :name %>
     <%= form.text_field :name %>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: category) do |form| %>
-  <%= render 'shared/error_messages', object: f.object %>
+  <%= render 'shared/error_messages', object: form.object %>
   <div class="field">
     <%= form.label :name %>
     <%= form.text_field :name %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,15 +1,7 @@
 <div class="container justify-content-center text-center">
   <div class="row">
     <%= form_with(model: event) do |form| %>
-      <% if event.errors.any? %>
-        <div id="error_explanation">
-            <% event.errors.each do |error| %>
-              <li><%= error.full_message %></li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
-
+      <%= render 'shared/error_messages', object: form.object %>
       <div class="row justify-content-center my-5 h5">
         <div class=" col-2 orange text-start">
           <%= form.label :title, class: "col-form-label" %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id="error_messages" class="alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if object.errors.any? %>
-  <div id="error_messages" class="alert alert-danger">
+  <div id="error_messages" class="alert alert-danger error_msg_with_errors">
     <ul class="mb-0">
       <% object.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,5 +1,4 @@
 <%= form_with(model: user) do |form| %>
-  <%= render 'shared/error_messages', object: form.object %>
   <div class="field">
     <%= form.label :name %>
     <%= form.text_field :name %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,16 +1,5 @@
 <%= form_with(model: user) do |form| %>
-  <% if user.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
-
-      <ul>
-        <% user.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
+  <%= render 'shared/error_messages', object: form.object %>
   <div class="field">
     <%= form.label :name %>
     <%= form.text_field :name %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -8,14 +8,7 @@
 <div class="container justify-content-center text-center">
   <div class="row">
     <%= form_with(model: @user) do |form| %>
-      <% if @user.errors.any? %>
-        <div id="error_explanation">
-            <% @user.errors.each do |error| %>
-              <li><%= error.full_message %></li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
+      <%= render 'shared/error_messages', object: form.object %>
 
       <div class="row justify-content-center my-5 h5">
         <div class=" col-2 orange text-end">


### PR DESCRIPTION
## 概要
エラーメッセージがそれぞれのフォームに記述してあった部分を共通化しました。

## 詳細
- 共通して使えるエラーメッセージのパーシャルを作成
- 各form箇所でrenderする記述
- 少しレイアウトを調整

## 確認方法
- merge後エラーメッセージの表示を確認してください！

## コメント
パーシャルで実装したあとエラーメッセージのレイアウトが少し気になったので
少し微調整しました。表示で気になる点があればコメントいただけると幸いです！ 
issue #64 にて確認できます！

カテゴリーのみ共通化したパーシャルで幅を指定した関係上
表示位置が中央によってしまうのですが、ユーザーが使用することはないと思いますので
パーシャル化しないorこのままかご意見伺いたいです！

あと一点気になる点があったのでコメントに残します！