### PR TITLE
参加キャンセル時の確認を追加

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -40,7 +40,7 @@
     <div class="row text-center mt-4">
     <div class="col-12">
       <% if @event.created_by?(current_user) %>
-        <%= link_to 'Pickable', event_pickable_path(@event), { method: :post, data: { confirm: 'Pickableを発動しますか？' }, class: "btn btn-outline-info-pick rounded-pill fz25 #{ 'disabled' if @event.pickable_counts > 0 }" } %>
+        <%= link_to 'Pickable', event_pickable_path(@event), { method: :post, data: { confirm: "Pickableを発動しますか？\n※1回しか発動できません。" }, class: "btn btn-outline-info-pick rounded-pill fz25 #{ 'disabled' if @event.pickable_counts > 0 }" } %>
 
         <div class="row justify-content-center mt-3">
           <div class="col-1">
@@ -63,7 +63,7 @@
   <div class="row text-center mt-4">
     <div class="col-12">
       <% if logged_in? && current_user.participating_events.include?(@event) %>
-        <%= link_to event_participation_path(@event), method: :delete do %>
+        <%= link_to event_participation_path(@event), method: :delete, data: { confirm: '参加をキャンセルしてもよろしいですか？' } do %>
           <div class="btn btn-outline-info rounded-pill fz15">キャンセル</div>
         <% end %>
       <% else %>


### PR DESCRIPTION
## 概要
#102 に基づき、参加キャンセル時に確認アラートを追加しました！

## やったこと
- [x] キャンセル時に確認アラート表示
- [x] Pickable発動時のアラート文変更

## 動作確認
[![Image from Gyazo](https://i.gyazo.com/5c445f5c12decab4d63fd138da2b5617.gif)](https://gyazo.com/5c445f5c12decab4d63fd138da2b5617)
[![Image from Gyazo](https://i.gyazo.com/f7aaf7c97ca3ae73e62222f2afd453f2.png)](https://gyazo.com/f7aaf7c97ca3ae73e62222f2afd453f2)

## Close Issues
Close #102