### PR TITLE
feat: モーダル機能実装 #87

### DIFF
--- a/app/assets/stylesheets/event.scss
+++ b/app/assets/stylesheets/event.scss
@@ -28,3 +28,39 @@
   border: 5px solid !important;
   text-decoration: none;
 }
+
+/* モーダルCSS */
+.modalArea {
+  display: none;
+  position: fixed;
+  z-index: 10; /*サイトによってここの数値は調整 */
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.modalBg {
+  width: 100%;
+  height: 100%;
+  background-color: rgba(30,30,30,0.8);
+}
+
+.modalWrapper {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform:translate(-50%,-50%);
+  width: 70%;
+  max-width: 800px;
+  padding: 10px 30px;
+  background-color: #FFFDE1;
+  border: 4px solid  #FF9D76;
+}
+
+.closeModal {
+  position: absolute;
+  top: 0.5rem;
+  right: 1rem;
+  cursor: pointer;
+}

--- a/app/javascript/packs/common.js
+++ b/app/javascript/packs/common.js
@@ -9,3 +9,15 @@ document.addEventListener('turbolinks:load', window.buttonClick = function butto
     // txtArea.value = ""; 切り替えでカテゴリー選択のチェックを外す記述。とりあえずOFF
   }
 });
+
+// events#showモーダル
+document.addEventListener('turbolinks:load', window.buttonClick = function buttonClick() {
+  $(function () {
+    $('#openModal').click(function(){
+        $('#modalArea').fadeIn();
+    });
+    $('#closeModal , #modalBg').click(function(){
+      $('#modalArea').fadeOut();
+    });
+  });
+});

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -43,7 +43,7 @@
         <%= link_to 'Pickable', event_pickable_path(@event), { method: :post, data: { confirm: "Pickableを発動しますか？\n※1回しか発動できません。" }, class: "btn btn-outline-info-pick rounded-pill fz25 #{ 'disabled' if @event.pickable_counts > 0 }" } %>
 
         <div class="row justify-content-center mt-2">
-          <a href="javascript:void(0)" id="openModal" class="col-2">Pickableとは？</a>
+          <a href="javascript:void(0)" id="openModal" class="col-2 hover-target simple-a-tag"><i class="fa-regular fa-circle-question"></i> Pickableとは</a>
         </div>
         <!-- モーダルエリアここから -->
         <section id="modalArea" class="modalArea">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -42,6 +42,25 @@
       <% if @event.created_by?(current_user) %>
         <%= link_to 'Pickable', event_pickable_path(@event), { method: :post, data: { confirm: "Pickableを発動しますか？\n※1回しか発動できません。" }, class: "btn btn-outline-info-pick rounded-pill fz25 #{ 'disabled' if @event.pickable_counts > 0 }" } %>
 
+        <div class="row justify-content-center mt-2">
+          <a href="javascript:void(0)" id="openModal" class="col-2">Pickableとは？</a>
+        </div>
+        <!-- モーダルエリアここから -->
+        <section id="modalArea" class="modalArea">
+          <div id="modalBg" class="modalBg"></div>
+          <div class="modalWrapper">
+            <div class="modalContents">
+              <div class="h2 red">Pickableとは？</div>
+              <p class="h5 mt-3">イベント参加者を登録ユーザーからランダムでピックアップする機能のこと！</p>
+              <p>※ 1回のみ使用可能</p>
+            </div>
+            <div id="closeModal" class="closeModal">
+              ×
+            </div>
+          </div>
+        </section>
+        <!-- モーダルエリアここまで -->
+
         <div class="row justify-content-center mt-3">
           <div class="col-1">
             <%= link_to edit_event_path(@event), class: "col-auto h2 hover-target text-center simple-a-tag" do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,5 +19,7 @@
     <% end %>
     <%= render 'shared/flash_message' %>
     <%= yield %>
+
+    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
events#showページのPickableボタンの下に説明モーダルをつけました！
一般的なモーダルで右上の×ボタンかモーダル外をタップで閉じます。
参考サイト（https://myscreate.com/pure-modal/）
[![Image from Gyazo](https://i.gyazo.com/d514dca12948aed1e61214ad82eb1b6e.gif)](https://gyazo.com/d514dca12948aed1e61214ad82eb1b6e)