### PR TITLE
Event design #103

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,8 +57,12 @@ body {
 }
 
 // 共通
+// レイアウト
 .flex {
   display: flex;
+}
+.w-60 {
+  width: 60% !important;
 }
 
 // フォントサイズ
@@ -71,7 +75,6 @@ body {
 .fz12 {
   font-size: 1.2rem !important;
 }
-
 .fz075 {
   font-size: 0.75rem;
 }

--- a/app/assets/stylesheets/event.scss
+++ b/app/assets/stylesheets/event.scss
@@ -15,7 +15,6 @@
   color: black;
 }
 
-
 .event-link {
   text-decoration: none;
 }
@@ -27,6 +26,11 @@
   border-color: #FF4273 !important;
   border: 5px solid !important;
   text-decoration: none;
+}
+
+.desc {
+  background-color: #fff;
+  border: #FF9D76 2px solid;
 }
 
 /* モーダルCSS */

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,6 +9,7 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.find(params[:id])
+    @participated_users = @event.participating_users
   end
 
   def new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,7 +22,7 @@ class EventsController < ApplicationController
 
     if @event.save
       current_user.participate(@event)
-      redirect_to event_path(@event), success: 'イベントが作成されました。'
+      redirect_to event_path(@event), success: 'イベントを作成しました。'
     else
       render :new
     end
@@ -30,7 +30,7 @@ class EventsController < ApplicationController
 
   def update
     if @event.update(event_params)
-      redirect_to event_path(@event), success: 'イベントが更新されました。'
+      redirect_to event_path(@event), success: 'イベントを更新しました。'
     else
       render :edit
     end
@@ -39,7 +39,7 @@ class EventsController < ApplicationController
   def destroy
     EventCancelMailer.with(event: @event).event_cancel.deliver_now
     @event.destroy
-    redirect_to events_path, success: 'イベントが削除されました。'
+    redirect_to events_path, success: 'イベントを中止しました。'
   end
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,7 +22,7 @@ class EventsController < ApplicationController
 
     if @event.save
       current_user.participate(@event)
-      redirect_to event_path(@event), success: 'Event was successfully created.'
+      redirect_to event_path(@event), success: 'イベントが作成されました。'
     else
       render :new
     end
@@ -30,7 +30,7 @@ class EventsController < ApplicationController
 
   def update
     if @event.update(event_params)
-      redirect_to event_path(@event), success: 'Event was successfully updated.'
+      redirect_to event_path(@event), success: 'イベントが更新されました。'
     else
       render :edit
     end
@@ -39,7 +39,7 @@ class EventsController < ApplicationController
   def destroy
     EventCancelMailer.with(event: @event).event_cancel.deliver_now
     @event.destroy
-    redirect_to events_path, success: 'Event was successfully destroyed.'
+    redirect_to events_path, success: 'イベントが削除されました。'
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -39,7 +39,7 @@ class Event < ApplicationRecord
   validate :past_scheduled_date
 
   def past_scheduled_date
-    if scheduled_date != nil && Time.current >= scheduled_date
+    if !scheduled_date.nil? && Time.current >= scheduled_date
       errors.add(:scheduled_date,
                  'は、現在時刻以降を入力して下さい')
     end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -22,11 +22,15 @@
       <%= @event.category.name %>
     </div>
   </div>
-  <div class="row text-center mt-5">
-    <div class="h4 text-center mx-auto mt-2 col-8">
+
+
+  <div class="h5 text-start lh-base mx-auto col-7 mt-5 desc">
+    <div class="p-3">
+      <div class="text-center skyblue mb-3">イベント詳細</div>
       <%= raw Rinku.auto_link(simple_format(h(@event.description), {}, sanitize: false, wrapper_tag: "div") ,:all, 'target="_blank"' 'rel="noopener noreferrer"')%>
     </div>
   </div>
+
 
   <div class="row text-center mt-5">
     <div class="mb-2">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -37,11 +37,11 @@
       メンバー  <%= @event.participations.size %> / <%= @event.number_of_members %>
     </div>
     <div class="justify-content-start row w-60 ms-4">
-      <% @event.participations.each do |participation|%>
+      <% @participated_users.each do |participated_user|%>
         <div class="col-2 my-2">
           <div><%= image_tag 'pick.png', class: 'rounded-circle', size: '50x50' %></div>
-          <%# <%= image_tag participation.user.remote_avatar_url, class: 'rounded-circle', size: '50x50' %>
-          <div class="text-wrap text-break my-2 fz075"><%= participation.user.name %></div>
+          <%# <%= image_tag participated_user.user.remote_avatar_url, class: 'rounded-circle', size: '50x50' %>
+          <div class="text-wrap text-break my-2 fz075"><%= participated_user.name %></div>
         </div>
       <% end %>
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -32,16 +32,19 @@
   </div>
 
 
-  <div class="row text-center mt-5">
-    <div class="mb-3">
+  <div class="row text-center mt-5 justify-content-center">
+    <div class="mb-2">
       メンバー  <%= @event.participations.size %> / <%= @event.number_of_members %>
     </div>
-    <% @event.participations.each do |participation|%>
-      <div class="col-1 mx-auto">
-        <%= image_tag participation.user.remote_avatar_url, class: 'rounded-circle', size: '50x50' %>
-        <div class="text-wrap text-break fz075 mt-1"><%= participation.user.name %></div>
-      </div>
-    <% end %>
+    <div class="justify-content-start row w-60 ms-4">
+      <% @event.participations.each do |participation|%>
+        <div class="col-2 my-2">
+          <div><%= image_tag 'pick.png', class: 'rounded-circle', size: '50x50' %></div>
+          <%# <%= image_tag participation.user.remote_avatar_url, class: 'rounded-circle', size: '50x50' %>
+          <div class="text-wrap text-break my-2 fz075"><%= participation.user.name %></div>
+        </div>
+      <% end %>
+    </div>
   </div>
 
     <div class="row text-center mt-4">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -8,17 +8,21 @@
     <div class="display-6">
       <%= l @event.scheduled_date, format: :short %>
     </div>
-    <div class="h5 mt-1">
+    <div class="h5 mt-2">
       ＠  <%= @event.place %>
     </div>
-    <div>
+    <div class="h5 mt-1">
+      <strong><i class="fa-solid fa-user"></i></strong>
+      <%= @event.user.name %>
+    </div>
+  </div>
+
+  <div class="row text-center mt-2">
     <div class="badge bg-category mx-auto col-1 fz12 mt-1">
       <%= @event.category.name %>
     </div>
-    <div class="mt-5">
-      <strong>主催：</strong>
-      <%= @event.user.name %>
-    </div>
+  </div>
+  <div class="row text-center mt-5">
     <div class="h4 text-center mx-auto mt-2 col-8">
       <%= raw Rinku.auto_link(simple_format(h(@event.description), {}, sanitize: false, wrapper_tag: "div") ,:all, 'target="_blank"' 'rel="noopener noreferrer"')%>
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -33,14 +33,13 @@
 
 
   <div class="row text-center mt-5">
-    <div class="mb-2">
+    <div class="mb-3">
       メンバー  <%= @event.participations.size %> / <%= @event.number_of_members %>
     </div>
     <% @event.participations.each do |participation|%>
       <div class="col-1 mx-auto">
-        <%# <%= image_tag participation.user.remote_avatar_url, class: 'rounded-circle', size: '50x50' %1> %>
-        <div><%= image_tag 'pick.png', class: 'rounded-circle', size: '50x50' %></div>
-        <div class="text-wrap text-break"><%= participation.user.name %></div>
+        <%= image_tag participation.user.remote_avatar_url, class: 'rounded-circle', size: '50x50' %>
+        <div class="text-wrap text-break fz075 mt-1"><%= participation.user.name %></div>
       </div>
     <% end %>
   </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -100,4 +100,4 @@
     </div>
   </div>
 
-  <div class="row mt-3"><%= link_to 'Back', events_path %></div>
+  <div class="row col-1 mx-auto m-3"><%= link_to 'Back', events_path %></div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -100,4 +100,4 @@
     </div>
   </div>
 
-  <div class="row col-1 mx-auto m-3"><%= link_to 'Back', events_path %></div>
+  <div class="row col-1 text-center mx-auto m-3"><%= link_to 'Back', events_path %></div>


### PR DESCRIPTION
#99 #103 をまとめて変更しました！

### Events#showページのレイアウト変更点
- イベント詳細を左寄せに
- 短文の時に不恰好になってしまうので、背景色＋ボーダー＋イベント詳細（水色）の追加
- メンバーのアイコンを各自のGitHubアイコンに
- メンバーの名前を小さめに
- Backボタンのマージン調整

#### 文字数多め＋改行あり
[![Image from Gyazo](https://i.gyazo.com/fb97bd356fe4a1f610c4be6fcc5f129a.png)](https://gyazo.com/fb97bd356fe4a1f610c4be6fcc5f129a)


#### 短文
[![Image from Gyazo](https://i.gyazo.com/01f064d8b2b1cd941efe4a5075bba22b.png)](https://gyazo.com/01f064d8b2b1cd941efe4a5075bba22b)