### PR TITLE
Fix: 他ユーザー詳細ページにそのユーザーの参加イベントが表示されるように修正 #121

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,8 +5,8 @@ class UsersController < ApplicationController
   def edit; end
 
   def show
-    participated_events = @user.participating_events
-                                      .eager_load(:category, :participations)
+    participated_events =
+      @user.participating_events.eager_load(:category, :participations)
 
     @events_from_today = participated_events.from_today
     @events_till_yesterday = participated_events.till_yesterday

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
   def edit; end
 
   def show
-    participated_events = current_user.participating_events
+    participated_events = @user.participating_events
                                       .eager_load(:category, :participations)
 
     @events_from_today = participated_events.from_today

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,7 +32,7 @@ class Event < ApplicationRecord
 
   validates :title, presence: true
   validates :description, presence: true
-  validates :number_of_members, presence: true, numericality: { greater_than: 1, less_than: 201 }
+  validates :number_of_members, presence: true, numericality: { greater_than: 1, less_than: 101 }
   validates :scheduled_date, presence: true
   validates :place, presence: true
   validates :pickable_counts, presence: true, inclusion: { in: 0..1 }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,7 +32,7 @@ class Event < ApplicationRecord
 
   validates :title, presence: true
   validates :description, presence: true
-  validates :number_of_members, presence: true, numericality: { greater_than: 1 }
+  validates :number_of_members, presence: true, numericality: { greater_than: 1, less_than: 201 }
   validates :scheduled_date, presence: true
   validates :place, presence: true
   validates :pickable_counts, presence: true, inclusion: { in: 0..1 }

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -32,7 +32,7 @@
 
       <div class="row justify-content-center mb-5 h5">
         <%= form.label :number_of_members, class: "col-form-label col-2 offset-2 orange text-start" %>
-        <%= form.number_field :number_of_members, class: "col-form-control col-6 h6", max: 200, min: 0 %>
+        <%= form.number_field :number_of_members, class: "col-form-control col-6 h6", max: 200, min: 2 %>
       </div>
 
       <div class="row justify-content-center mb-5 h5">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -32,7 +32,7 @@
 
       <div class="row justify-content-center mb-5 h5">
         <%= form.label :number_of_members, class: "col-form-label col-2 offset-2 orange text-start" %>
-        <%= form.number_field :number_of_members, class: "col-form-control col-6 h6", max: 200, min: 2 %>
+        <%= form.number_field :number_of_members, class: "col-form-control col-6 h6", max: 100, min: 2 %>
       </div>
 
       <div class="row justify-content-center mb-5 h5">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -32,7 +32,7 @@
 
       <div class="row justify-content-center mb-5 h5">
         <%= form.label :number_of_members, class: "col-form-label col-2 offset-2 orange text-start" %>
-        <%= form.number_field :number_of_members, class: "col-form-control col-6 h6" %>
+        <%= form.number_field :number_of_members, class: "col-form-control col-6 h6", max: 200, min: 0 %>
       </div>
 
       <div class="row justify-content-center mb-5 h5">


### PR DESCRIPTION
## 概要
#121 の不具合を修正
users#showアクションでcurrent_userから参加イベントを取っていたのを、`:id`でとってきたユーザーからに変更し修正しました！

## 確認方法
自分のページ
https://gyazo.com/1a15a042e9981c0914c865b064d741f9
他ユーザーのページ
https://gyazo.com/26266bec4cd67157221d03ad97c5b74b

## 影響範囲
- users/show

## チェックリスト
- [x] 修正
- [x] 動作確認
- [x] rubocop

## Close Issues
Close #121