### PR TITLE
ユーザー編集時のカテゴリーを選択を必須に変更

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -30,7 +30,7 @@ class Event < ApplicationRecord
   belongs_to :user
   belongs_to :category
 
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 38 }
   validates :description, presence: true
   validates :number_of_members, presence: true, numericality: { greater_than: 1 }
   validates :scheduled_date, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,7 @@ class User < ApplicationRecord
   validates :hiyoconne_url, uniqueness: true,
                             format: { with: %r{\A\z|\Ahttps://hiyoco-connect\.herokuapp\.com/profiles/\d{1,3}\Z},
                                       message: 'が不正なURLです。誤解だったらゴメンね！' }, allow_blank: true
+  validate :checked_categories
 
   enum role: { general: 0, admin: 1 }
   enum accept_random: { accepted: 0, denied: 1 }
@@ -56,5 +57,13 @@ class User < ApplicationRecord
 
   def participated?(event)
     participating_events.include? event
+  end
+
+  private
+
+  def checked_categories
+    if accept_random == 'accepted' && categories.empty?
+      errors.add(:category, 'を選択してください')
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,6 @@ class User < ApplicationRecord
   private
 
   def checked_categories
-    errors.add(:category, 'を1つ以上選択してください') if accept_random == 'accepted' && categories.empty?
+    errors.add(:category, 'を1つ以上選択してください') if accepted? && categories.empty?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,6 @@ class User < ApplicationRecord
   private
 
   def checked_categories
-    errors.add(:category, 'を選択してください') if accept_random == 'accepted' && categories.empty?
+    errors.add(:category, 'を1つ以上選択してください') if accept_random == 'accepted' && categories.empty?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,8 +62,6 @@ class User < ApplicationRecord
   private
 
   def checked_categories
-    if accept_random == 'accepted' && categories.empty?
-      errors.add(:category, 'を選択してください')
-    end
+    errors.add(:category, 'を選択してください') if accept_random == 'accepted' && categories.empty?
   end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -36,6 +36,7 @@
       <div class="row justify-content-center h5" id="select-category">
         <div class="col-2 orange text-start offset-3">
           <%= form.label :category_id, class: "col-form-label align-middle" %>
+          <span class="red small">*</span>
         </div>
         <div class="col-6 my-auto row h4">
           <%= form.collection_check_boxes(:category_ids, Category.all, :id, :name) do |b| %>

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -19,7 +19,7 @@ ja:
         role: 権限
         category_id: 希望ジャンル
         hiyoconne_url: ひよコネリンク
-        category: ジャンル
+        category: 希望ジャンル 
       event:
         title: タイトル
         description: 詳細

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -19,6 +19,7 @@ ja:
         role: 権限
         category_id: 希望ジャンル
         hiyoconne_url: ひよコネリンク
+        category: ジャンル
       event:
         title: タイトル
         description: 詳細


### PR DESCRIPTION
## 概要
#124 に基づき、ユーザー編集時に`WELCOME`だとカテゴリー選択を必須にしました！ 
#125 に基づき、イベントタイトルの文字数を38文字に制限しています！

## やったこと
- [x] `WELCOME`でカテゴリーが未選択だとエラーを表示
- [x] エラー表示の日本語化
- [x] イベントタイトルの文字数制限

## 動作確認
`WELCOME`
[![Image from Gyazo](https://i.gyazo.com/095c6ea5a9e439310139dbc7b9623670.gif)](https://gyazo.com/095c6ea5a9e439310139dbc7b9623670)
`SLEEPING`
[![Image from Gyazo](https://i.gyazo.com/d1a5fa3181a1a03c0f953ab4f6401a86.gif)](https://gyazo.com/d1a5fa3181a1a03c0f953ab4f6401a86)

## Close Issues
Close #124 #125 