### PR TITLE
style: Pickable時, イベントキャンセル時のメールのレイアウトを修正する

### DIFF
--- a/app/views/mailers/event_cancel_mailer/event_cancel.html.erb
+++ b/app/views/mailers/event_cancel_mailer/event_cancel.html.erb
@@ -11,7 +11,7 @@
       </div>
       <div>
         <p class="fwb">詳細</p>
-        <p class="pl20"><%= simple_format(@event.description) %></p>
+        <p class="pl20"><%= simple_format(h(@event.description)) %></p>
       </div>
       <div>
         <p class="fwb">開催日時</p>

--- a/app/views/mailers/event_cancel_mailer/event_cancel.html.erb
+++ b/app/views/mailers/event_cancel_mailer/event_cancel.html.erb
@@ -11,7 +11,7 @@
       </div>
       <div>
         <p class="fwb">詳細</p>
-        <p class="pl20"><%= @event.description %></p>
+        <p class="pl20"><%= simple_format(@event.description) %></p>
       </div>
       <div>
         <p class="fwb">開催日時</p>

--- a/app/views/mailers/pickable_mailer/report_pickable.html.erb
+++ b/app/views/mailers/pickable_mailer/report_pickable.html.erb
@@ -11,7 +11,7 @@
       </div>
       <div>
         <p class="fwb">詳細</p>
-        <p class="pl20"><%= simple_format(@event.description) %></p>
+        <p class="pl20"><%= simple_format(h(@event.description)) %></p>
       </div>
       <div>
         <p class="fwb">開催日時</p>

--- a/app/views/mailers/pickable_mailer/report_pickable.html.erb
+++ b/app/views/mailers/pickable_mailer/report_pickable.html.erb
@@ -11,7 +11,7 @@
       </div>
       <div>
         <p class="fwb">詳細</p>
-        <p class="pl20"><%= @event.description %></p>
+        <p class="pl20"><%= simple_format(@event.description) %></p>
       </div>
       <div>
         <p class="fwb">開催日時</p>


### PR DESCRIPTION
## 概要
issue #116 に基づいて修正をしました。 
イベントキャンセル時のイベント詳細, pickable通知のイベント詳細部分で改行が適用されて
いなかった部分を修正しました。

## 確認方法
merge後にメールを確認よろしくお願いします！

## ToDo

- [x]  各viewの詳細部分にsimple_formatを追加

## コメント
#116 に各メールの表示を画像で追加しているので確認をよろしくお願いします！
