### PR TITLE
Fix: #134とイベント作成時のcategoryバリデーションのエラーメッセージの修正 #134

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
   <% if current_user == @user %>
     <%= t('.title') %>
   <% else %>
-    <%= "#{@user.name}'s Page" %>
+    <%= "#{@user.name}’s Page" %>
   <% end %>
 <% end %>
 

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -24,6 +24,7 @@ ja:
         scheduled_date: イベント開始日時
         place: 開催場所
         category_id: ジャンル
+        category: ジャンル
         # 所要時間を追加してください
   enums:
     user:


### PR DESCRIPTION
## 概要
#134 の修正、および #132 にて生じていた、イベント作成、更新時にカテゴリー未選択時のバリデーションエラーメッセージで一部日本語化されなくなっていた不具合を修正しました！
確認不足でお手数おかけして申し訳ございませんが、お手すきでご確認お願いします…！🙇🏻‍♂️

## 確認方法
マージ後に以下の確認をお願いします。
- 他ユーザーの詳細ページでのタイトルが文字化けしていないか
- カテゴリー未選択でイベント作成した際に「ジャンルを選択してください」というエラーメッセージが出るか
 
## チェックリスト
- [x] 不具合の修正
- [x] 動作確認
- [x] rubocop

## コメント
Filechangedに直記します！

## Close Issues
Close #134 