### PR TITLE
終了したイベントでのPickable発動をできないように変更

### DIFF
--- a/app/controllers/pickables_controller.rb
+++ b/app/controllers/pickables_controller.rb
@@ -24,5 +24,7 @@ class PickablesController < ApplicationController
     else
       redirect_to event, danger: t('.fail')
     end
+  rescue ActiveRecord::RecordInvalid
+    redirect_to event, danger: t('.failed')
   end
 end

--- a/app/controllers/pickables_controller.rb
+++ b/app/controllers/pickables_controller.rb
@@ -25,6 +25,6 @@ class PickablesController < ApplicationController
       redirect_to event, danger: t('.fail')
     end
   rescue ActiveRecord::RecordInvalid
-    redirect_to event, danger: t('.failed')
+    redirect_to event, danger: t('.is_past')
   end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <div class="h5 mt-3">
-      <% unless @event.timescale.to_s == "0001-01-01 00:00:00 +0918" %>
+      <% if @event.timescale && @event.timescale.to_s != "0001-01-01 00:00:00 +0918" %>
         <div class="text-center"><i class="fa-solid fa-hourglass"></i>  <%= l @event.timescale, format: :very_short %></div>
       <% end %>
     </div>
@@ -36,7 +36,7 @@
   <div class="h5 text-start lh-base mx-auto col-7 mt-5 desc">
     <div class="p-3">
       <div class="text-center skyblue mb-3">イベント詳細</div>
-      <%= raw Rinku.auto_link(simple_format(h(@event.description), {}, sanitize: false, wrapper_tag: "div") ,:all, 'target="_blank"' 'rel="noopener noreferrer"')%>
+      <%= raw Rinku.auto_link(simple_format(h(@event.description), sanitize: false) ,:all, 'target="_blank"' 'rel="noopener noreferrer"')%>
     </div>
   </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,13 @@
 <div class="container justify-content-center text-center my-5">
   <div class="row py-3">
     <div class="col">
-      <h1 class="red"><%= t('.title') %></h1>
+      <h1 class="red">
+        <% if current_user == @user %>
+          <%= t('.title') %>
+        <% else %>
+          <%= "#{@user.name}’s Page" %>
+        <% end %>
+      </h1>
     </div>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -50,6 +50,7 @@ ja:
     create:
       success: Pickableを発動しました
       fail: Pickable発動は一度限りです
+      failed: 終了したイベントです
 
   static_pages:
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -50,7 +50,7 @@ ja:
     create:
       success: Pickableを発動しました
       fail: Pickable発動は一度限りです
-      failed: 終了したイベントです
+      is_past: 終了したイベントです
 
   static_pages:
 


### PR DESCRIPTION
## 概要
#129 に基づき、終了したイベントでのPickable発動をできないようにしました！

## やったこと
- [ ] 終了したイベントでPickable発動できないように変更。
- [ ] イベント詳細の改行を反映
- [ ] ユーザー詳細のタイトルを動的に変更

## Close Issues
Close #129