### PR TITLE
イベント参加者のソートと過去イベントの表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,8 +36,8 @@ gem 'rails-i18n', '~> 6.0'
 gem 'sorcery'
 
 # ページネーション
-gem 'kaminari'
 gem 'bootstrap5-kaminari-views'
+gem 'kaminari'
 
 # cssをinline変換
 gem 'premailer-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'sorcery'
 
 # ページネーション
 gem 'kaminari'
+gem 'bootstrap5-kaminari-views'
 
 # cssをinline変換
 gem 'premailer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,9 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.10.3)
       msgpack (~> 1.2)
+    bootstrap5-kaminari-views (0.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     builder (3.2.4)
     bullet (7.0.1)
       activesupport (>= 3.0.0)
@@ -351,6 +354,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.4)
+  bootstrap5-kaminari-views
   bullet
   byebug
   enum_help

--- a/app/assets/stylesheets/event.scss
+++ b/app/assets/stylesheets/event.scss
@@ -88,3 +88,7 @@
   right: 1rem;
   cursor: pointer;
 }
+
+.border-orange {
+  border-top: 5px solid #FF9D76 !important;
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,8 +4,8 @@ class EventsController < ApplicationController
 
   def index
     events = Event.eager_load(:category, :participations)
-    @events_from_today = events.from_today
-    @events_till_yesterday = events.till_yesterday
+    @events_from_today = events.from_today.page(params[:future_page]).per(10)
+    @events_till_yesterday = events.till_yesterday.page(params[:past_page]).per(10)
   end
 
   def show

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -51,7 +51,7 @@ class EventsController < ApplicationController
   end
 
   def event_params
-    params.require(:event).permit(:title, :description, :number_of_members, :scheduled_date, :timescale,
-                                  :place, :user_id, :category_id)
+    params.require(:event).permit(:title, :description, :number_of_members, :scheduled_date,
+                                  :timescale, :place, :user_id, :category_id)
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -5,7 +5,7 @@ class EventsController < ApplicationController
   def index
     events = Event.eager_load(:category, :participations)
     @events_from_today = events.from_today.page(params[:future_page]).per(10)
-    @events_till_yesterday = events.till_yesterday.page(params[:past_page]).per(10)
+    @events_till_yesterday = events.till_yesterday.page(params[:past_page]).per(5)
   end
 
   def show

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,8 +3,9 @@ class EventsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
 
   def index
-    @events =
-      Event.eager_load(:category, :participations).from_today.page(params[:page]).per(10)
+    events =Event.eager_load(:category, :participations)
+    @events_from_today = events.from_today
+    @events_till_yesterday = events.till_yesterday
   end
 
   def show

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,7 @@ class EventsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
 
   def index
-    events =Event.eager_load(:category, :participations)
+    events = Event.eager_load(:category, :participations)
     @events_from_today = events.from_today
     @events_till_yesterday = events.till_yesterday
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,7 +9,7 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.find(params[:id])
-    @participated_users = @event.participating_users
+    @participated_users = @event.participating_users.order(:id)
   end
 
   def new

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -11,7 +11,34 @@
       <% end %>
     </div>
   </div>
-  <%= render 'shared/event', events: @events %>
 </div>
 
-<%= paginate @events %>
+<div class="container">
+  <div class="row justify-content-center my-5">
+    <h1 class="col-auto orange">
+      本日以降開催のイベント
+    </h1>
+  </div>
+  <% if @events_from_today %>
+    <%= render 'shared/event', events: @events_from_today %>
+  <% else %>
+    <h4 class="col-auto text-muted ">
+      開催予定のイベントはありません。<br>
+      過去のイベントを参考に主催してみよう！
+    </h4>
+  <% end %>
+</div>
+
+<div class="row justify-content-center my-5 pt-5">
+  <div class="col-6 border-orange">
+  </div>
+</div>
+
+<div class="container">
+  <div class="row justify-content-center my-5 py-5">
+    <h1 class="col-auto orange">
+      過去に開催されたイベント
+    </h1>
+  </div>
+  <%= render 'shared/event', events: @events_till_yesterday %>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -16,7 +16,7 @@
 <div class="container">
   <div class="row justify-content-center my-5">
     <h1 class="col-auto orange">
-      本日以降開催のイベント
+      開催予定のイベント
     </h1>
   </div>
   <% if @events_from_today %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -22,7 +22,7 @@
   <% if @events_from_today %>
     <%= render 'shared/event', events: @events_from_today %>
     <div class="col-auto">
-      <%= paginate @events_from_today, :param_name => 'future_page', theme: 'bootstrap-5' %>
+      <%= paginate @events_from_today, param_name: 'future_page', theme: 'bootstrap-5' %>
     </div>
   <% else %>
     <h4 class="col-auto text-muted ">
@@ -47,7 +47,7 @@
     <%= render 'shared/event', events: @events_till_yesterday %>
     <div class="row justify-content-center">
       <div class="col-auto">
-        <%= paginate @events_till_yesterday, :param_name => 'past_page', theme: 'bootstrap-5' %>
+        <%= paginate @events_till_yesterday, param_name: 'past_page', theme: 'bootstrap-5' %>
       </div>
     </div>
   <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -21,6 +21,9 @@
   </div>
   <% if @events_from_today %>
     <%= render 'shared/event', events: @events_from_today %>
+    <div class="col-auto">
+      <%= paginate @events_from_today, :param_name => 'future_page', theme: 'bootstrap-5' %>
+    </div>
   <% else %>
     <h4 class="col-auto text-muted ">
       開催予定のイベントはありません。<br>
@@ -40,5 +43,12 @@
       過去に開催されたイベント
     </h1>
   </div>
-  <%= render 'shared/event', events: @events_till_yesterday %>
+  <% if @events_till_yesterday %>
+    <%= render 'shared/event', events: @events_till_yesterday %>
+    <div class="row justify-content-center">
+      <div class="col-auto">
+        <%= paginate @events_till_yesterday, :param_name => 'past_page', theme: 'bootstrap-5' %>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -69,5 +69,9 @@ ja:
     formats:
       very_short: "%H時間%M分"
 
-
-
+  views:
+    pagination:
+      first: <i class="fas fa-angle-double-left"></i>
+      last: <i class="fas fa-angle-double-right"></i>
+      previous: <i class="fas fa-angle-left"></i>
+      next: <i class="fas fa-angle-right"></i>


### PR DESCRIPTION
## 概要
頂いたご意見をもとに作成した #140 #138 に基づき
- イベント詳細ページでの参加者の表示を参加順にソート
- イベント一覧ページで過去イベントを表示
- イベント一覧ページで現在以降のイベントと過去イベントにそれぞれページネーションを実装

以上、3点の変更を行いました！
↓一覧ページの表示
[![Image from Gyazo](https://i.gyazo.com/a9aea8bd06c93253df06acf2aa05a3a4.gif)](https://gyazo.com/a9aea8bd06c93253df06acf2aa05a3a4)



## 確認方法
ページネーションのデザインのため、kaminariにbootstrapを適用するgemを導入しているので新規機能の開発時は`bundle install`をお願いします。

## 影響範囲
- events/inex.html.erb
- events_controller

## チェックリスト
- 参加者のソート
- 一覧での過去イベント表示
- 現在以降のイベントと過去イベントそれぞれにページネーションを実装
- 動作確認
- rubocop

## コメント
Filechangesに直記します！

## Close Issues
Close #140 Close #138 